### PR TITLE
Fix to display values larger than 999.

### DIFF
--- a/examples/Arduino/TFTDisplayText/TFTDisplayText.ino
+++ b/examples/Arduino/TFTDisplayText/TFTDisplayText.ino
@@ -61,7 +61,7 @@ void loop() {
   String sensorVal = String(analogRead(A0));
  
   // convert the reading to a char array
-  sensorVal.toCharArray(sensorPrintout, 4);
+  sensorVal.toCharArray(sensorPrintout, 5);
 
   // set the font color
   TFTscreen.stroke(255,255,255);


### PR DESCRIPTION
Change the `sensorVal.toCharArray` bufsize to `5` so it can display values larger than 999 wich a sensor like a photoresistor could give.